### PR TITLE
Massively improve startup time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,13 +63,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: DOF2DMD
-          path: .\DOF2DMD\bin\Release\net8.0-windows\win-x64\publish
+          path: .\DOF2DMD\bin\Release\net8.0-windows\publish
           retention-days: 7
 
       - name: Generate zip bundle
         run: |
           # tree /f
-          7z a -tzip DOF2DMD.zip .\DOF2DMD\bin\Release\net8.0-windows\win-x64\publish\*
+          7z a -tzip DOF2DMD.zip .\DOF2DMD\bin\Release\net8.0-windows\publish\*
       
       - if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
         name: Publish latest pre-release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,14 +49,14 @@ jobs:
         run: |
           copy FlexDMD.dll dof2dmd
           copy DmdDevice64.dll dof2dmd
-          dotnet publish -r win-x64 --self-contained=false /p:PublishSingleFile=true dof2dmd/dof2dmd.csproj /p:Version=${{ github.ref_name }}
+          dotnet publish /p:Version=${{ github.ref_name }}
 
       - if: "!startsWith(github.ref, 'refs/tags/')"
         name: Build
         run: |
           copy FlexDMD.dll dof2dmd
           copy DmdDevice64.dll dof2dmd
-          dotnet publish -r win-x64 --self-contained=false /p:PublishSingleFile=true dof2dmd/dof2dmd.csproj
+          dotnet publish
 
       # Upload artifacts
       - name: Upload artifacts

--- a/DOF2DMD/dof2dmd.csproj
+++ b/DOF2DMD/dof2dmd.csproj
@@ -3,17 +3,13 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>
-    <PublishSingleFile>true</PublishSingleFile>
+    <PublishSingleFile>false</PublishSingleFile>
     <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
     <DebugType Condition=" '$(Configuration)' == 'Release' ">None</DebugType>
+    <!-- Enable .NET 8 performance optimizations -->
+    <EnableDynamicPGO>true</EnableDynamicPGO>
+    <OptimizationPreference>Speed</OptimizationPreference>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Content Include="DmdDevice64.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-    </Content>
-  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="8.0.0" />
@@ -29,51 +25,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="settings.ini">
+    <Content Include="DmdDevice64.dll;settings.ini;demo*.ps1">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+    </Content>
+
+    <Content Include="artwork/*.{png,gif};artwork/**/*;resources/**/*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
     </Content>
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="demo.ps1">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="demo2.ps1">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="artwork/DOF2DMD.png">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="artwork/MatrixCode.gif">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="artwork/ingame/**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="artwork/mame/**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-    </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="resources/**">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-    </Content>
-  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Startup is now multithreaded. The http listener starts right away, which allows DOFLinx to start DOF2DMD and continue. The DMD may take few more seconds to start, while DOFLinx already starts to send pictures. This is accounted for by adding a logic in DisplayPicture to wait (up to 10 seconds) while the initialization thread does its job. Meanwhile, requests to display images are queued.
Additionally, the packaging is reviewed so that there is no decompression when launching the app, at the cost of many more files in the package (but not an issue really).
Overall, this release goes from about 10 seconds startup time down to less than 1 second, with 2/3 more seconds for the DMD to be functional and display picture.