### PR TITLE
New: queueing of animations,  better logging

### DIFF
--- a/DOF2DMD/Program.cs
+++ b/DOF2DMD/Program.cs
@@ -1167,7 +1167,7 @@ namespace DOF2DMD
                                     bool sCleanbg;
                                     if (!bool.TryParse(query.Get("cleanbg"), out sCleanbg))
                                     {
-                                        sCleanbg = false; // valor predeterminado si la conversión falla
+                                        sCleanbg = true; // valor predeterminado si la conversión falla
                                     }
 
                                     if (!DisplayScore(gNbPlayers, gActivePlayer, gScore[gActivePlayer], sCleanbg, gCredits))

--- a/DOF2DMD/Program.cs
+++ b/DOF2DMD/Program.cs
@@ -348,13 +348,12 @@ namespace DOF2DMD
             gNbPlayers = cPlayers;
             gCredits = credits;
             _scoreDelayTimer?.Dispose();
-            
             // If no ongoing animation or we can display score over it
-            if (_animationTimer == null || sCleanbg == false)
+            if (_animationTimer == null || sCleanbg == false || _currentDuration == -1)
             {
                 LogIt($"DisplayScore for player {player}: {score}");
                 DisplayScoreboard(gNbPlayers, player, gScore[1], gScore[2], gScore[3], gScore[4], "", "", sCleanbg);
-            }
+            } 
             return true;
 
         }
@@ -575,12 +574,10 @@ namespace DOF2DMD
                         // For image, set duration to infinite (9999s)
                         duration = (isVideo && duration == 0) ? ((AnimatedActor)mediaActor).Length :
                                    (isImage && duration == 0) ? 9999 : duration;
-                        if (isVideo)
-                        {
-                            // Arm timer once animation is done playing
-                            _animationTimer?.Dispose();
-                            _animationTimer = new Timer(AnimationTimer, null, (int)duration * 1000, Timeout.Infinite);
-                        }
+
+                        // Arm timer once animation is done playing
+                        _animationTimer?.Dispose();
+                        _animationTimer = new Timer(AnimationTimer, null, (int)(duration * 1000), Timeout.Infinite);
         
                         BackgroundScene bg = CreateBackgroundScene(gDmdDevice, mediaActor, animation.ToLower(), duration);
         
@@ -1092,7 +1089,7 @@ namespace DOF2DMD
                                     {
                                         pictureduration = -1.0f;
                                     }
-                                    if ((query.Count == 2) && (pictureduration == -1.0f) && !picturepath.Contains("mameoutput"))
+                                    if (!picturepath.Contains("mameoutput"))
                                     {
                                         // This is certainly a game marquee, provided during new game
                                         // If path corresponds to an existing file, set game marquee
@@ -1149,7 +1146,7 @@ namespace DOF2DMD
                                     string animationIn = query.Get("animationin") ?? "none";
                                     string animationOut = query.Get("animationout") ?? "none";
                                     float advtextduration = float.TryParse(query.Get("duration"), out float aresult) ? aresult : 5.0f;
-                                    LogIt($"Advanced Text is now set to: {advtext} with size {advsize} ,color {advcolor} ,font {advfont} ,border color {advbordercolor}, border size {advbordersize}, animation In {animationIn}, animation Out {animationOut} with a duration of {advtextduration} seconds");
+                                    LogIt($"Advanced Text is now set to: {advtext} with size {advsize}, color {advcolor}, font {advfont}, border color {advbordercolor}, border size {advbordersize}, animation In {animationIn}, animation Out {animationOut} with a duration of {advtextduration} seconds");
                                     bool advcleanbg;
                                     if (!bool.TryParse(query.Get("cleanbg"), out advcleanbg))
                                     {

--- a/DOF2DMD/Program.cs
+++ b/DOF2DMD/Program.cs
@@ -110,7 +110,6 @@ namespace DOF2DMD
         private static float _currentDuration;
         
         private static Timer _scoreDelayTimer;
-        private static readonly object _scoreLock = new object();
 
         static async Task Main()
         {
@@ -350,9 +349,8 @@ namespace DOF2DMD
             gCredits = credits;
             _scoreDelayTimer?.Dispose();
             
-            // Check if animationtimer is running, meaning that there is an ongoing animation (explosion, etc.)
-            // If there is, don't display score yet, the animationtimer will take care of it
-            if (_animationTimer == null)
+            // If no ongoing animation or we can display score over it
+            if (_animationTimer == null || sCleanbg == false)
             {
                 LogIt($"DisplayScore for player {player}: {score}");
                 DisplayScoreboard(gNbPlayers, player, gScore[1], gScore[2], gScore[3], gScore[4], "", "", sCleanbg);
@@ -555,7 +553,12 @@ namespace DOF2DMD
                             (Actor)gDmdDevice.NewVideo("MyVideo", fullPath) : 
                             (Actor)gDmdDevice.NewImage("MyImage", fullPath);
                         mediaActor.SetSize(gDmdDevice.Width, gDmdDevice.Height);
-        
+                        // Handle looping for GIFs when duration is -1
+                        if (isVideo && duration < 0)
+                        {
+                            LogIt($"🔄 Setting video loop to true for {fullPath}");
+                            ((AnimatedActor)mediaActor).Loop = true;
+                        }
                         _currentDuration = duration;
                         // If duration is negative - show immediately and clear the animation queue
                         if (duration < 0)
@@ -1118,7 +1121,7 @@ namespace DOF2DMD
                                     string bordersize = query.Get("bordersize") ?? "0";
                                     string animation = query.Get("animation") ?? "none";
                                     float textduration = float.TryParse(query.Get("duration"), out float tresult) ? tresult : 5.0f;
-                                    LogIt($"Text is now set to: {text} with size {size} ,color {color} ,font {font} ,border color {bordercolor}, border size {bordersize}, animation {animation} with a duration of {textduration} seconds");
+                                    LogIt($"Text is now set to: {text} with size {size}, color {color}, font {font}, border color {bordercolor}, border size {bordersize}, animation {animation} with a duration of {textduration} seconds");
                                     bool cleanbg;
                                     if (!bool.TryParse(query.Get("cleanbg"), out cleanbg))
                                     {

--- a/DOF2DMD/Program.cs
+++ b/DOF2DMD/Program.cs
@@ -269,12 +269,7 @@ namespace DOF2DMD
                 LogIt("⏱️ DelayedScoreDisplay: delay complete, displaying score");
                 if (gScore[gActivePlayer] > 0)
                 {
-                    DisplayScore(gNbPlayers, gActivePlayer, gScore[gActivePlayer], true, gCredits);
-                }
-                if (AppSettings.ScoreDmd != 0)
-                {
-                    _scoreTimer?.Dispose();
-                    _scoreTimer = new Timer(ScoreTimer, null, AppSettings.displayScoreDuration * 1000, Timeout.Infinite);
+                    DisplayScore(gNbPlayers, gActivePlayer, gScore[gActivePlayer], false, gCredits);
                 }
             }
         }
@@ -541,17 +536,22 @@ namespace DOF2DMD
                         gDmdDevice.Clear = true;
         
                         // Clear existing resources
-                        if (_queue.ChildCount >= 1)
-                        {
-                            _queue.RemoveAllScenes();
-                        }
+                         _queue.RemoveAllScenes();
                         gDmdDevice.Graphics.Clear(Color.Black);
                         _scoreDelayTimer?.Dispose();
+                        _scoreDelayTimer = null;
                         _scoreBoard.Visible = false;
                         Actor mediaActor = isVideo ? 
                             (Actor)gDmdDevice.NewVideo("MyVideo", fullPath) : 
                             (Actor)gDmdDevice.NewImage("MyImage", fullPath);
                         mediaActor.SetSize(gDmdDevice.Width, gDmdDevice.Height);
+
+                        // Set random position if the file name contains "expl" (explosion?)
+                        if (fullPath.Contains("expl"))
+                        {
+                            mediaActor.SetPosition(new Random().Next(-1, 2) * 32, 0);
+
+                        }
                         // Handle looping for GIFs when duration is -1
                         if (isVideo && duration < 0)
                         {
@@ -1123,7 +1123,7 @@ namespace DOF2DMD
                                     if (!bool.TryParse(query.Get("cleanbg"), out cleanbg))
                                     {
                                         cleanbg = true; // valor predeterminado si la conversión falla
-                                    } 
+                                    }
                                     bool loop;
                                     if (!bool.TryParse(query.Get("loop"), out loop))
                                     {
@@ -1167,7 +1167,7 @@ namespace DOF2DMD
                                     bool sCleanbg;
                                     if (!bool.TryParse(query.Get("cleanbg"), out sCleanbg))
                                     {
-                                        sCleanbg = true; // valor predeterminado si la conversión falla
+                                        sCleanbg = false; // valor predeterminado si la conversión falla
                                     }
 
                                     if (!DisplayScore(gNbPlayers, gActivePlayer, gScore[gActivePlayer], sCleanbg, gCredits))

--- a/README.md
+++ b/README.md
@@ -89,11 +89,15 @@ There are example aseprite files in [the `ingame.src` folder](/DOF2DMD/artwork/i
 
 DOF2DMD is a server listening to simple http request. Once it has started, you can use the following :
 
-- `[url_prefix]/v1/display/picture?path=<image or video path>&animation=<fade|ScrollRight|ScrollLeft|ScrollUp|ScrollDown|None>&duration=<seconds>`  
+- `[url_prefix]/v1/display/picture?path=<image or video path>&animation=<fade|ScrollRight|ScrollLeft|ScrollUp|ScrollDown|None>&duration=<seconds>&queue`  
   Display an image, gif animation or video.
   - **path**: The file path of the image or video to be displayed
-  - **duration**: If the duration is 0 in an animation/video, it will be limited to the duration of the video or animation. If the time is -1, it will be permanent
+  - **duration**:
+    - 0: picture will be displayed indefinitely, and animation will be displayed for the duration of the video or animation. 
+    - >0: picture or animation will be displayed for the specified time in seconds
+    - <0: picture or animation will be looped indefinitely
   - **animation**: The animation applied to the scene fade|ScrollRight|ScrollLeft|ScrollUp|ScrollDown|None
+  - **queue**: If present, the image will be queued to be displayed after the current image is finished. If not present, the current image will be replaced immediately by the new one
 - `[url_prefix]/v1/display/score?players=<number of players>&player=<active player>&score=<score>&cleanbg=<true|false>`  
   Display a score board using a layout from 1 to 4 players and credits**
   - **players**: the number of players for score layout. Optional, default 1


### PR DESCRIPTION
- Now supports queueing of Display picture with parameter `&queue`. If present, the image will be queued to be displayed after the current image is finished based on "duration" parameter. If not present, the current image will be replaced immediately by the new one
- Better determination of what the game marquee is
- Debugging : displays version in the logs, show thread ID, properly show log emojis in the console when debug is on
- Score display is delayed by 1s, so that we keep some time to display other animations if they arrive
- Display explosions (files with "expl" in their names) in random positions for more pop
